### PR TITLE
Fix OG images for proposals and accommodations

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(python3:*)",
       "Bash(git rebase:*)",
       "Bash(git stash:*)",
-      "WebFetch(domain:api.github.com)"
+      "WebFetch(domain:api.github.com)",
+      "Bash(find:*)"
     ]
   }
 }

--- a/apps/kitasuro/src/app/accomodations/[id]/opengraph-image.tsx
+++ b/apps/kitasuro/src/app/accomodations/[id]/opengraph-image.tsx
@@ -1,0 +1,158 @@
+import { ImageResponse } from 'next/og';
+import { createServerCaller } from '@/server/trpc/caller';
+import { getPublicUrl } from '@/lib/storage';
+
+export const size = { width: 1200, height: 630 };
+
+const cormorantBold = fetch(
+  'https://fonts.gstatic.com/s/cormorantgaramond/v21/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_hg9GnM.ttf',
+).then((res) => res.arrayBuffer());
+
+// Convert image URL to PNG via wsrv.nl proxy (next/og doesn't support WebP)
+function toOgSafeUrl(url: string): string {
+  return `https://wsrv.nl/?url=${encodeURIComponent(url)}&output=png&w=1200&h=630&fit=cover`;
+}
+
+export default async function OGImage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const trpc = await createServerCaller();
+  const acc = await trpc.accommodations.getById({ id });
+
+  if (!acc) {
+    return new ImageResponse(
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#1a1a1a',
+          color: '#ffffff',
+          fontSize: 48,
+        }}
+      >
+        Accommodation not found
+      </div>,
+      { ...size },
+    );
+  }
+
+  const firstImage = acc.images[0];
+  const heroImage = firstImage
+    ? toOgSafeUrl(getPublicUrl(firstImage.bucket, firstImage.key))
+    : null;
+
+  const details: string[] = [];
+  if (acc.country) details.push(acc.country);
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        position: 'relative',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      {/* Background image or gradient */}
+      {heroImage ? (
+        <img
+          src={heroImage}
+          alt=""
+          width={1200}
+          height={630}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+          }}
+        />
+      ) : null}
+
+      {/* Dark overlay */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          background: heroImage
+            ? 'linear-gradient(to top, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0.3) 50%, rgba(0,0,0,0.15) 100%)'
+            : 'linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)',
+        }}
+      />
+
+      {/* Content */}
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'flex-end',
+          padding: '48px 56px',
+        }}
+      >
+        {/* Name */}
+        <div
+          style={{
+            color: '#ffffff',
+            fontSize: 56,
+            fontFamily: 'Cormorant Garamond',
+            fontWeight: 700,
+            lineHeight: 1.15,
+            maxWidth: '85%',
+            display: 'flex',
+            flexWrap: 'wrap',
+          }}
+        >
+          {acc.name}
+        </div>
+
+        {/* Details row */}
+        {details.length > 0 ? (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              marginTop: '16px',
+            }}
+          >
+            {details.map((detail, i) => (
+              <span
+                key={i}
+                style={{
+                  color: 'rgba(255,255,255,0.8)',
+                  fontSize: 24,
+                  fontWeight: 400,
+                }}
+              >
+                {detail}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>,
+    {
+      ...size,
+      fonts: [
+        {
+          name: 'Cormorant Garamond',
+          data: await cormorantBold,
+          style: 'normal',
+          weight: 700,
+        },
+      ],
+    },
+  );
+}

--- a/apps/kitasuro/src/app/accomodations/[id]/page.tsx
+++ b/apps/kitasuro/src/app/accomodations/[id]/page.tsx
@@ -1,3 +1,5 @@
+import { cache } from 'react';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { ArrowLeft, Globe, MapPin } from 'lucide-react';
@@ -7,11 +9,44 @@ import { createServerCaller } from '@/server/trpc/caller';
 import { ImageGallery } from '../_components/ImageGallery';
 import { ContentDisplay } from '../_components/ContentDisplay';
 
-export default async function AccommodationDetailPage({
-  params,
-}: {
+type Props = {
   params: Promise<{ id: string }>;
-}) {
+};
+
+const getCachedAccommodation = cache(async (id: string) => {
+  const trpc = await createServerCaller();
+  return trpc.accommodations.getById({ id });
+});
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const acc = await getCachedAccommodation(id);
+
+  if (!acc) {
+    return { title: 'Accommodation not found' };
+  }
+
+  const description = acc.overview || acc.enhancedDescription?.slice(0, 160) || acc.name;
+
+  return {
+    title: acc.name,
+    description,
+    openGraph: {
+      title: acc.name,
+      description,
+      type: 'website',
+      images: [
+        {
+          url: `/accomodations/${id}/opengraph-image`,
+          width: 1200,
+          height: 630,
+        },
+      ],
+    },
+  };
+}
+
+export default async function AccommodationDetailPage({ params }: Props) {
   const resolvedParams = await params;
   const id = resolvedParams?.id;
 
@@ -19,8 +54,7 @@ export default async function AccommodationDetailPage({
     notFound();
   }
 
-  const trpc = await createServerCaller();
-  const acc = await trpc.accommodations.getById({ id });
+  const acc = await getCachedAccommodation(id);
 
   if (!acc) {
     notFound();

--- a/apps/kitasuro/src/app/proposal/[id]/opengraph-image.tsx
+++ b/apps/kitasuro/src/app/proposal/[id]/opengraph-image.tsx
@@ -4,6 +4,10 @@ import { format } from 'date-fns';
 
 export const size = { width: 1200, height: 630 };
 
+const cormorantBold = fetch(
+  'https://fonts.gstatic.com/s/cormorantgaramond/v21/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_hg9GnM.ttf',
+).then((res) => res.arrayBuffer());
+
 // Convert image URL to PNG via wsrv.nl proxy (next/og doesn't support WebP)
 function toOgSafeUrl(url: string | null | undefined): string | null {
   if (!url) return null;
@@ -147,6 +151,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
             style={{
               color: '#ffffff',
               fontSize: 56,
+              fontFamily: 'Cormorant Garamond',
               fontWeight: 700,
               lineHeight: 1.15,
               maxWidth: '85%',
@@ -232,6 +237,16 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
         </div>
       </div>
     </div>,
-    { ...size },
+    {
+      ...size,
+      fonts: [
+        {
+          name: 'Cormorant Garamond',
+          data: await cormorantBold,
+          style: 'normal',
+          weight: 700,
+        },
+      ],
+    },
   );
 }

--- a/apps/kitasuro/src/app/proposal/[id]/page.tsx
+++ b/apps/kitasuro/src/app/proposal/[id]/page.tsx
@@ -60,6 +60,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: orgName ? `${title} — ${orgName}` : title,
       description,
       type: 'website',
+      images: [
+        {
+          url: `/proposal/${id}/opengraph-image`,
+          width: 1200,
+          height: 630,
+        },
+      ],
     },
   };
 }


### PR DESCRIPTION
## Summary
- **Proposal page**: Added explicit `openGraph.images` to `generateMetadata` so the dynamic OG image is properly linked in meta tags (was missing, causing WhatsApp previews to fail)
- **Accommodation page**: Added `generateMetadata` with title, description, and OG image support (had none before)
- **New accommodation OG image**: Created `/accomodations/[id]/opengraph-image.tsx` that generates a 1200x630 image with the accommodation photo and name
- **Cormorant Garamond font**: Both OG images now use the same serif font as the Discovery Theme for the title

## Test plan
- [ ] Visit `/proposal/[id]/opengraph-image` directly — should render the image with serif font title
- [ ] Visit `/accomodations/[id]/opengraph-image` directly — should render accommodation image with name overlay
- [ ] Check `og:image` meta tag is present on both page types via `curl` or view-source
- [ ] After deploy, validate with https://www.opengraph.xyz and Facebook debugger
- [ ] Test WhatsApp link preview for both proposal and accommodation URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)